### PR TITLE
catch error when accessing potentially cors object

### DIFF
--- a/src/build.js
+++ b/src/build.js
@@ -24,6 +24,11 @@ fs.writeFileSync(
                 '!sameOriginCheck(window1Location, window2Location)',
                 '!(sameOriginCheck(window1Location, window2Location) && (!!window1["%is-hammerhead%"] === !!window2["%is-hammerhead%"]))'
             )
+            // return false when unable to convert properties on other windows to booleans (!)
+            .replace(
+                /!(parentWindow|window1|window2|window\.top)\[("%(?:is-)?hammerhead%")]/g,
+                '!(() => { try{ return $1[$2]; }catch(error){ return false } })()'
+            )
 
             // disable saving to localStorage as we are using a completely different implementation
             .replace('saveToNativeStorage = function () {', 'saveToNativeStorage = function () {return;')

--- a/src/build.js
+++ b/src/build.js
@@ -26,7 +26,7 @@ fs.writeFileSync(
             )
             // return false when unable to convert properties on other windows to booleans (!)
             .replace(
-                /!(parentWindow|window1|window2|window\.top)\[("%(?:is-)?hammerhead%")]/g,
+                /!(parent|parentWindow|window1|window2|window\.top)\[("%(?:is-)?hammerhead%")]/g,
                 '!(() => { try{ return $1[$2]; }catch(error){ return true } })()'
             )
 

--- a/src/build.js
+++ b/src/build.js
@@ -27,7 +27,7 @@ fs.writeFileSync(
             // return false when unable to convert properties on other windows to booleans (!)
             .replace(
                 /!(parentWindow|window1|window2|window\.top)\[("%(?:is-)?hammerhead%")]/g,
-                '!(() => { try{ return $1[$2]; }catch(error){ return false } })()'
+                '!(() => { try{ return $1[$2]; }catch(error){ return true } })()'
             )
 
             // disable saving to localStorage as we are using a completely different implementation


### PR DESCRIPTION
In my situation, I have rammerhead running on a subdomain (rh.) and it is contained inside an iframe on the root domain. Because rammerhead attempts to access %hammerhead% on other window objects, I get this error:
> Uncaught DOMException: Permission denied to access property "%hammerhead%" on cross-origin object

This will replace all instances of rammerhead checking if the %hammerhead% and %is-hammerhead% property exists on a window with a self-invoking function that will return the property on the window or false if an error was caught in the try catch wrapper.

Example code that is affected:
```js
const topIsHammerhead = !window.top["%is-hammerhead%"]; // false if top doesn't contain "%is-hammerhead%" or top is on a different origin
// won't change:
window.top["%hammerhead%"];
```